### PR TITLE
Fix: 회원가입 페이지에서 이메일과 비밀번호 데이터가 다른 페이지로 옮겨가도록 수정

### DIFF
--- a/src/pages/signup/Signup.jsx
+++ b/src/pages/signup/Signup.jsx
@@ -38,8 +38,8 @@ export default function Signup() {
     const [pwMsg, setPwMsg] = useState('* 영어, 숫자포함해서 8자 이상 입력해주세요');
     const navigate = useNavigate();
     const [btnState, setBtnState] = useState('disabled');
+    const [signupData, setSignupData] = useState(null);
     let { signupInfo } = useContext(SignupContext);
-    let signupData = {};
 
     useEffect(() => {
         if (emailMsg === '* 사용 가능한 이메일 입니다.' && pwMsg === '') {
@@ -57,10 +57,7 @@ export default function Signup() {
         } else {
             emailRef.current.classList.remove('active');
         }
-        signupData = {
-            email: emailRef.current.value,
-            password: pwRef.current.value,
-        };
+        setSignupData({ user: { email: emailRef.current.value, password: pwRef.current.value } });
     };
 
     async function handleEmailValid() {
@@ -88,7 +85,7 @@ export default function Signup() {
         // error가 없을 때 context값 변경하고 링크 이동
         signupInfo.user = {
             ...signupInfo.user,
-            ...signupData,
+            ...signupData.user,
         };
         console.log(signupInfo);
         // newUser = { ...newUser, ...signupData };
@@ -101,8 +98,8 @@ export default function Signup() {
         // 여기에 조건식 ? <SignupForm/>:<SignupProfile/>
         <SignupForm>
             <h2>이메일로 회원가입</h2>
-            <Form action="">
-                <InputDiv ref={emailRef} onChange={handleChange} onBlur={handleEmailValid} text="이메일" type="email" />
+            <Form action=''>
+                <InputDiv ref={emailRef} onChange={handleChange} onBlur={handleEmailValid} text='이메일' type='email' />
                 <ErrorMessage text={emailMsg} />
                 <InputDiv
                     ref={pwRef}
@@ -110,11 +107,11 @@ export default function Signup() {
                         handlePwValid();
                         handleChange();
                     }}
-                    text="비밀번호"
-                    type="password"
+                    text='비밀번호'
+                    type='password'
                 />
                 <ErrorMessage text={pwMsg} />
-                <CustomButton onClick={handleSubmit} size="L" state={btnState}>
+                <CustomButton onClick={handleSubmit} size='L' state={btnState}>
                     다음
                 </CustomButton>
             </Form>


### PR DESCRIPTION
### 🌱 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 
- [ ] 스타일 : 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정 : 이메일과 비밀번호 데이터가 컨텍스트에 잘 담기도록 수정
- [ ] 기타 : 


### 🌱 기대 결과
- 회원가입 페이지에서 입력한 이메일과 비밀번호가 다른 페이지로 잘 넘어갈 것이다!


### 🌱 전달사항
-


### 🌱 스크린샷


### 🌱 Issue Number
close : #
